### PR TITLE
fix to work with bladerf 2.0 API

### DIFF
--- a/bladerf.go
+++ b/bladerf.go
@@ -169,7 +169,7 @@ func SetLoopback(bladeRF *BladeRF, loopback loopback.Loopback) error {
 }
 
 func SetFrequency(bladeRF *BladeRF, channel channel.Channel, frequency int) error {
-	return GetError(C.bladerf_set_frequency((*bladeRF).ref, C.bladerf_channel(channel), C.ulonglong(frequency)))
+	return GetError(C.bladerf_set_frequency((*bladeRF).ref, C.bladerf_channel(channel), C.bladerf_frequency(frequency)))
 }
 
 func SetSampleRate(bladeRF *BladeRF, channel channel.Channel, sampleRate int) error {


### PR DESCRIPTION
if you try to log onto your personal computer and do some magic with radios using this neato golang abstraction of the libbladerf library you will likely be disappointed when you're left with this:

```
bladerf.go:172:130: cannot use _Ctype_ulonglong(frequency) (type _Ctype_ulonglong) as type _Ctype_ulong in assignment
FAIL github.com/erayarslan/go-bladerf [build failed]
```

[this is due to the breaking changes implemented by release 2.0](https://nuand.com/libbladeRF-doc/v2.2.1/relnotes_2_0.html)

changing the type in bladerf_set_frequency to bladerf_frequency fixes it, but it probably won't resurrect your dead cat

have a terrific day